### PR TITLE
Use relative_require to load helper code

### DIFF
--- a/lib/puppet/provider/mount/parsed.rb
+++ b/lib/puppet/provider/mount/parsed.rb
@@ -1,5 +1,5 @@
 require 'puppet/provider/parsedfile'
-require 'puppet/provider/mount'
+require_relative '../mount'
 
 fstab = case Facter.value(:osfamily)
         when 'Solaris' then '/etc/vfstab'


### PR DESCRIPTION
Use relative_require to load helper code so that the provider can be
autoloaded, even if the autoloader hasn't added the module's lib
directory to the ruby $LOAD_PATH.