### PR TITLE
Expand test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ script:
   - 'bundle exec rake $CHECK'
 bundler_args: --without system_tests
 rvm:
-  - 2.4.1
+  - 2.5.3
 env:
   global:
-    - BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_GEM_VERSION="~> 5.0"
+    - PUPPET_GEM_VERSION="~> 6.0"
 matrix:
   fast_finish: true
   include:
@@ -24,6 +24,12 @@ matrix:
       env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     -
       env: CHECK=parallel_spec
+    -
+      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
+      rvm: 2.4.5
+    -
+      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
+      rvm: 2.1.9
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 1. [Description](#description)
 2. [Setup - The basics of getting started with mount_core](#setup)
     * [What mount_core affects](#what-mount_core-affects)
-    * [Beginning with mount_core](#beginning-with-mount_core)
 3. [Usage - Configuration options and additional functionality](#usage)
 4. [Limitations - OS compatibility, etc.](#limitations)
 5. [Development - Guide for contributing to the module](#development)
@@ -33,7 +32,7 @@ either ancestors of the mounted directory or children. This way Puppet will
 automatically create ancestor directories before the mount point, and will do
 that before managing directories and files within the mounted directory.
 
-### Beginning with mount_core
+## Usage
 
 To mount the device `/dev/foo` at `/mnt/foo` as read-only, use the following code:
 
@@ -46,13 +45,9 @@ mount { '/mnt/foo':
 }
 ```
 
-## Usage
-
-For details on usage, please see [the mount puppet docs](https://puppet.com/docs/puppet/latest/types/mount.html).
-
 ## Reference
 
-Please see `REFERENCE.md` for the reference documentation.
+Please see [`REFERENCE.md`](REFERENCE.md) for the reference documentation.
 
 This module is documented using Puppet Strings.
 

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "summary": "Manages mounted filesystems and mount tables.",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-mount_core",
-  "project_page": "https://github.com/puppetlabs/puppetlabs-mount_core/blob/master/README.md",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-mount_core",
   "issues_url": "https://tickets.puppetlabs.com/projects/MODULES",
   "dependencies": [
 

--- a/spec/unit/type/mount_spec.rb
+++ b/spec/unit/type/mount_spec.rb
@@ -512,6 +512,9 @@ describe Puppet::Type.type(:mount), unless: Puppet.features.microsoft_windows? d
     end
 
     def run_in_catalog(*resources)
+      # rubocop:disable RSpec/AnyInstance
+      Puppet::Transaction::Persistence.any_instance.stubs(:save) if Puppet.version.to_f < 5.0
+      # rubocop:enable RSpec/AnyInstance
       Puppet::Util::Storage.stubs(:store)
       catalog = Puppet::Resource::Catalog.new
       catalog.add_resource(*resources)


### PR DESCRIPTION
Expand test coverage to include Puppet4 & Puppet6. Update README (see MODULES-8182) and project metadata.