### PR TITLE
(MODULES-8304) Allow whitespace in mountpoints on Linux

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -47,10 +47,11 @@ mount/unmount status.
 
 ##### `device`
 
-The device providing the mount.  This can be whatever
-device is supporting by the mount, including network
-devices or devices specified by UUID rather than device
-path, depending on the operating system.
+The device providing the mount.  This can be whatever device
+is supporting by the mount, including network devices or
+devices specified by UUID rather than device path, depending
+on the operating system. On Linux systems it can contain
+whitespace.
 
 ##### `blockdevice`
 
@@ -100,7 +101,7 @@ The following parameters are available in the `mount` type.
 
 namevar
 
-The mount path for the mount.
+The mount path for the mount. On Linux systems it can contain whitespace.
 
 ##### `remounts`
 

--- a/lib/puppet/provider/mount.rb
+++ b/lib/puppet/provider/mount.rb
@@ -60,7 +60,7 @@ module Puppet::Provider::Mount
 
   # This only works when the mount point is synced to the fstab.
   def unmount
-    umount(resource[:name])
+    umount resource[:name]
 
     # Update property hash for future queries (e.g. refresh is called)
     case get(:ensure)

--- a/lib/puppet/type/mount.rb
+++ b/lib/puppet/type/mount.rb
@@ -124,13 +124,16 @@ Puppet::Type.newtype(:mount, self_refresh: true) do
   end
 
   newproperty(:device) do
-    desc "The device providing the mount.  This can be whatever
-        device is supporting by the mount, including network
-        devices or devices specified by UUID rather than device
-        path, depending on the operating system."
+    desc "The device providing the mount.  This can be whatever device
+        is supporting by the mount, including network devices or
+        devices specified by UUID rather than device path, depending
+        on the operating system. On Linux systems it can contain
+        whitespace."
 
     validate do |value|
-      raise Puppet::Error, _('device must not contain whitespace: %{value}') % { value: value } if value =~ %r{\s}
+      unless Facter.value(:kernel) == 'Linux'
+        raise Puppet::Error, _('device must not contain whitespace: %{value}') % { value: value } if value =~ %r{\s}
+      end
     end
   end
 
@@ -242,12 +245,14 @@ Puppet::Type.newtype(:mount, self_refresh: true) do
   end
 
   newparam(:name) do
-    desc 'The mount path for the mount.'
+    desc 'The mount path for the mount. On Linux systems it can contain whitespace.'
 
     isnamevar
 
     validate do |value|
-      raise Puppet::Error, _('name must not contain whitespace: %{value}') % { value: value } if value =~ %r{\s}
+      unless Facter.value(:kernel) == 'Linux'
+        raise Puppet::Error, _('name must not contain whitespace: %{value}') % { value: value } if value =~ %r{\s}
+      end
     end
 
     munge do |value|

--- a/spec/acceptance/tests/defined_spec.rb
+++ b/spec/acceptance/tests/defined_spec.rb
@@ -19,6 +19,20 @@ RSpec.context 'when managing mounts' do
           fail_test "didn't find the mount #{name}" unless result.stdout.include?(name)
         end
       end
+
+      it 'defines a mount entry with whitespace' do
+        step 'creates a mount'
+        args = ['ensure=defined',
+                "fstype=#{fs_type}",
+                "device='/tmp/#{name_w_whitespace}'"]
+        on(agent, puppet_resource('mount', "'/#{name_w_whitespace}'", args))
+
+        step 'verify entry in filesystem table'
+        on(agent, "cat #{fs_file}") do |result|
+          munged_name = name_w_whitespace.gsub(' ', '\\\040')
+          fail_test "didn't find the mount #{name_w_whitespace}" unless result.stdout.include?(munged_name)
+        end
+      end
     end
   end
 end

--- a/spec/acceptance/tests/destroy_spec.rb
+++ b/spec/acceptance/tests/destroy_spec.rb
@@ -38,6 +38,40 @@ RSpec.context 'when managing mounts' do
           fail_test "found the mount #{name} mounted" if result.stdout.include?(name)
         end
       end
+
+      it 'deletes an entry with whitespace in filesystem table and unmounts it' do
+        step 'create mount point'
+        on(agent, "mkdir '/#{name_w_whitespace}'", acceptable_exit_codes: [0, 1])
+
+        step 'create new filesystem to be mounted'
+        MountUtils.create_filesystem(agent, name_w_whitespace)
+
+        step 'add entry to the filesystem table'
+        MountUtils.add_entry_to_filesystem_table(agent, name_w_whitespace)
+
+        step 'mount entry'
+        on(agent, "mount '/#{name_w_whitespace}'")
+
+        step 'verify entry exists in filesystem table'
+        on(agent, "cat #{fs_file}") do |result|
+          munged_name = name_w_whitespace.gsub(' ', '\\\040')
+          fail_test "did not find mount '#{name_w_whitespace}'" unless result.stdout.include?(munged_name)
+        end
+
+        step 'destroy a mount with puppet (absent)'
+        on(agent, puppet_resource('mount', "'/#{name_w_whitespace}'", 'ensure=absent'))
+
+        step 'verify entry removed from filesystem table'
+        on(agent, "cat #{fs_file}") do |result|
+          munged_name = name_w_whitespace.gsub(' ', '\\\040')
+          fail_test "found the mount '#{name_w_whitespace}'" if result.stdout.include?(munged_name)
+        end
+
+        step 'verify entry is not mounted'
+        on(agent, 'mount') do |result|
+          fail_test "found the mount '#{name_w_whitespace}' mounted" if result.stdout.include?(name_w_whitespace)
+        end
+      end
     end
   end
 end

--- a/spec/acceptance/tests/modify_spec.rb
+++ b/spec/acceptance/tests/modify_spec.rb
@@ -30,6 +30,30 @@ RSpec.context 'when managing mounts' do
           fail_test "attributes not updated for the mount #{name}" unless res.stdout.include? 'bogus'
         end
       end
+
+      it 'modifies an entry with whitespace in the filesystem table' do
+        step '(setup) create mount point'
+        on(agent, "mkdir '/#{name_w_whitespace}'", acceptable_exit_codes: [0, 1])
+
+        step '(setup) create new filesystem to be mounted'
+        MountUtils.create_filesystem(agent, name_w_whitespace)
+
+        step '(setup) add entry to the filesystem table'
+        MountUtils.add_entry_to_filesystem_table(agent, name_w_whitespace)
+
+        step '(setup) mount entry'
+        on(agent, "mount '/#{name_w_whitespace}'")
+
+        step 'modify a mount with puppet (defined)'
+        args = ['ensure=defined',
+                'fstype=bogus']
+        on(agent, puppet_resource('mount', "'/#{name_w_whitespace}'", args))
+
+        step 'verify entry is updated in filesystem table'
+        on(agent, "cat #{fs_file}") do |res|
+          fail_test "attributes not updated for the mount '#{name_w_whitespace}'" unless res.stdout.include? 'bogus'
+        end
+      end
     end
   end
 end

--- a/spec/acceptance/tests/query_spec.rb
+++ b/spec/acceptance/tests/query_spec.rb
@@ -17,6 +17,16 @@ RSpec.context 'when managing mounts' do
         end
       end
 
+      it 'finds an existing filesystem table entry containing whitespace' do
+        step '(setup) add entry to filesystem table'
+        MountUtils.add_entry_to_filesystem_table(agent, name_w_whitespace)
+
+        step 'verify mount with puppet'
+        on(agent, puppet_resource('mount', "'/#{name_w_whitespace}'")) do |result|
+          fail_test "didn't find the mount #{name_w_whitespace}" unless result.stdout =~ %r{'/#{name_w_whitespace}':\s+ensure\s+=>\s+'unmounted'}
+        end
+      end
+
       # There is a discrepancy between how `puppet resource` and `puppet apply` handle this case.
       # With this patch, using a resource title with a trailing slash in `puppet apply` will match a mount resource without a trailing slash.
       # However, `puppet resource mount` with a trailing slash will not match.

--- a/spec/fixtures/unit/provider/mount/parsed/linux.fstab
+++ b/spec/fixtures/unit/provider/mount/parsed/linux.fstab
@@ -1,12 +1,15 @@
 # A sample fstab, typical for a Fedora system
-/dev/vg00/lv00          /                       ext3    defaults        1 1
-LABEL=/boot             /boot                   ext3    defaults        1 2
-devpts                  /dev/pts                devpts  gid=5,mode=620  0
-tmpfs                   /dev/shm                tmpfs   defaults        0
-LABEL=/home             /home                   ext3    defaults        1 2
-/home                   /homes                  auto    bind            0 2
-proc                    /proc                   proc    defaults        0 0
-/dev/vg00/lv01          /spare                  ext3    defaults        1 2
-sysfs                   /sys                    sysfs   defaults        0 0
-LABEL=SWAP-hda6         swap                    swap    defaults        0 0
-tmpfs                   /run/                   tmpfs   rw,nosuid,nodev,seclabel,mode=755        0 0
+/dev/vg00/lv00          /                                    ext3    defaults        1 1
+LABEL=/boot             /boot                                ext3    defaults        1 2
+devpts                  /dev/pts                             devpts  gid=5,mode=620  0
+tmpfs                   /dev/shm                             tmpfs   defaults        0
+LABEL=/home             /home                                ext3    defaults        1 2
+/home                   /homes                               auto    bind            0 2
+proc                    /proc                                proc    defaults        0 0
+/dev/vg00/lv01          /spare                               ext3    defaults        1 2
+sysfs                   /sys                                 sysfs   defaults        0 0
+LABEL=SWAP-hda6         swap                                 swap    defaults        0 0
+tmpfs                   /run/                                tmpfs   rw,nosuid,nodev,seclabel,mode=755        0 0
+/dev/white\040space     /white\040space                      ext3    rw,nosuid,nodev,seclabel,mode=755        0 0
+/dev/white\040space1    /unmounted\040white\040space         ext3    rw,nosuid,nodev,seclabel,mode=755        0 0
+/dev/white\040space2    /trailing\040white\040space/         ext3    rw,nosuid,nodev,seclabel,mode=755        0 0

--- a/spec/fixtures/unit/provider/mount/parsed/linux.mount
+++ b/spec/fixtures/unit/provider/mount/parsed/linux.mount
@@ -3,4 +3,7 @@ rc-svcdir on /lib64/rc/init.d type tmpfs (rw,nosuid,nodev,noexec,relatime,size=1
 sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
 /dev/sda9 on /usr/portage type jfs (rw)
 /dev/fake on /ghost type jfs (rw)
-tmpfs on /run tmpfs (rw,nosuid,nodev,seclabel,mode=755)
+tmpfs on /run type tmpfs (rw,nosuid,nodev,seclabel,mode=755)
+/dev/white space on /white space type ext3 (rw,nosuid,nodev,seclabel,mode=755)
+/dev/white space2 on /trailing white space type ext3 (rw,nosuid,nodev,seclabel,mode=755)
+/dev/white space3 on /ghost white space type ext3 (rw,nosuid,nodev,seclabel,mode=755)

--- a/spec/fixtures/unit/provider/mount/parsed/openbsd.mount
+++ b/spec/fixtures/unit/provider/mount/parsed/openbsd.mount
@@ -2,4 +2,4 @@
 /dev/wd0e on /home type ffs (local, nodev, nosuid)
 /dev/wd0d on /usr type ffs (local, nodev)
 /dev/wd0g on /ghost type ffs (local, nodev)
-tmpfs on /run (tmpfs, rw, nosuid, nodev, seclabel, mode=755)
+tmpfs on /run type tmpfs (rw, nosuid, nodev, seclabel, mode=755)

--- a/spec/integration/provider/mount_spec.rb
+++ b/spec/integration/provider/mount_spec.rb
@@ -32,7 +32,7 @@ describe 'mount provider (integration)', unless: Puppet.features.microsoft_windo
       when %r{/s?bin/mount}
         if command.length == 1
           if @mounted
-            "#{@current_device} on /Volumes/foo_disk (msdos, #{@current_options})\n"
+            "#{@current_device} on /Volumes/foo_disk type msdos (msdos, #{@current_options})\n"
           else
             ''
           end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,6 +20,7 @@ shared_context 'mount context' do |agent|
   let(:backup) { agent.tmpfile('mount-modify') }
   let(:name) { "pl#{rand(999_999).to_i}" }
   let(:name_w_slash) { "pl#{rand(999_999).to_i}\/" }
+  let(:name_w_whitespace) { "pl#{rand(999).to_i} #{rand(999).to_i}" }
 
   before(:each) do
     on(agent, "cp #{fs_file} #{backup}", acceptable_exit_codes: [0, 1])


### PR DESCRIPTION
This commit changes the mount type to accept whitespaces in mountpoint names and devices on Linux. This is accomplished by replacing the whitespace character with the ASCII code for space (`\040`) before writing to `/etc/fstab`.

When reading mountpoints from fstab, names and devices are munged back to the original whitespace character.

To make these changes as unintrusive as possible, the whitespace conversion is done by implementing the `to_line` and `post_parse` methods from the ParsedFile provider.