### PR TITLE
(MODULES-10953) Update metadata.json and pdk version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ end
 
 group :release do
   gem "puppet-blacksmith", '~> 3.4',                                             require: false
-  gem "pdk",                                                                     platforms: [:ruby]
+  gem "pdk", '~> 2.0',                                                           platforms: [:ruby]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/metadata.json
+++ b/metadata.json
@@ -12,70 +12,40 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "CentOS"
     },
     {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "OracleLinux"
     },
     {
-      "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "RedHat"
     },
     {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
-      ]
+      "operatingsystem": "Scientific"
     },
     {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "8"
-      ]
+      "operatingsystem": "Debian"
     },
     {
-      "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "16.04"
-      ]
+      "operatingsystem": "Ubuntu"
     },
     {
-      "operatingsystem": "Fedora",
-      "operatingsystemrelease": [
-        "28"
-      ]
+      "operatingsystem": "Fedora"
     },
     {
-      "operatingsystem": "Darwin",
-      "operatingsystemrelease": [
-        "16"
-      ]
+      "operatingsystem": "Darwin"
     },
     {
-      "operatingsystem": "SLES",
-      "operatingsystemrelease": [
-        "12"
-      ]
+      "operatingsystem": "SLES"
     },
     {
-      "operatingsystem": "Solaris",
-      "operatingsystemrelease": [
-        "11"
-      ]
+      "operatingsystem": "Solaris"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "1.14.0",

--- a/spec/integration/provider/mount_spec.rb
+++ b/spec/integration/provider/mount_spec.rb
@@ -20,13 +20,13 @@ describe 'mount provider (integration)', unless: Puppet.features.microsoft_windo
     @current_options = 'local'
     @current_device = '/dev/disk1s1'
     Puppet[:digest_algorithm] = 'md5'
-    Puppet::Type.type(:mount).defaultprovider.stubs(:default_target).returns(@fake_fstab)
-    Facter.stubs(:value).with(:hostname).returns('some_host')
-    Facter.stubs(:value).with(:domain).returns('some_domain')
-    Facter.stubs(:value).with(:kernel).returns('Linux')
-    Facter.stubs(:value).with(:operatingsystem).returns('RedHat')
-    Facter.stubs(:value).with(:osfamily).returns('RedHat')
-    Facter.stubs(:value).with(:fips_enabled).returns(false)
+    allow(Puppet::Type.type(:mount).defaultprovider).to receive(:default_target).and_return(@fake_fstab)
+    allow(Facter).to receive(:value).with(:hostname).and_return('some_host')
+    allow(Facter).to receive(:value).with(:domain).and_return('some_domain')
+    allow(Facter).to receive(:value).with(:kernel).and_return('Linux')
+    allow(Facter).to receive(:value).with(:operatingsystem).and_return('RedHat')
+    allow(Facter).to receive(:value).with(:osfamily).and_return('RedHat')
+    allow(Facter).to receive(:value).with(:fips_enabled).and_return(false)
     Puppet::Util::ExecutionStub.set do |command, _options|
       case command[0]
       when %r{/s?bin/mount}
@@ -75,8 +75,8 @@ describe 'mount provider (integration)', unless: Puppet.features.microsoft_windo
   def run_in_catalog(settings)
     resource = Puppet::Type.type(:mount).new(settings.merge(name: '/Volumes/foo_disk',
                                                             device: '/dev/disk1s1', fstype: 'msdos'))
-    Puppet::FileBucket::Dipper.any_instance.stubs(:backup) # Don't backup to the filebucket
-    resource.expects(:err).never
+    allow_any_instance_of(Puppet::FileBucket::Dipper).to receive(:backup) # Don't backup to the filebucket
+    expect(resource).not_to receive(:err)
     catalog = Puppet::Resource::Catalog.new
     catalog.host_config = false # Stop Puppet from doing a bunch of magic
     catalog.add_resource resource
@@ -112,7 +112,7 @@ describe 'mount provider (integration)', unless: Puppet.features.microsoft_windo
                 describe "When setting options => '#{options_setting}'" do
                   it "should leave the system in the #{expected_final_state ? 'mounted' : 'unmounted'} state, #{expected_fstab_data ? 'with' : 'without'} data in /etc/fstab" do
                     if family == 'Solaris'
-                      skip('Solaris: The mock :operatingsystem value does not get changed in lib/puppet/provider/mount/parsed.rb')
+                      skip('Solaris: The double :operatingsystem value does not get changed in lib/puppet/provider/mount/parsed.rb')
                     elsif options_setting && options_setting.empty?
                       expect { run_in_catalog(ensure: ensure_setting, options: options_setting) }.to raise_error Puppet::ResourceError
                     else

--- a/spec/lib/puppet_spec/files.rb
+++ b/spec/lib/puppet_spec/files.rb
@@ -10,7 +10,6 @@ module PuppetSpec::Files
   def self.cleanup
     until @global_tempfiles.empty?
       path = @global_tempfiles.pop
-      Dir.unstub(:entries)
       FileUtils.rm_rf path, secure: true
     end
   end

--- a/spec/shared_behaviours/all_parsedfile_providers.rb
+++ b/spec/shared_behaviours/all_parsedfile_providers.rb
@@ -5,7 +5,7 @@ shared_examples_for 'all parsedfile providers' do |provider, *files|
 
   files.flatten.each do |file|
     it "should rewrite #{file} reasonably unchanged" do
-      provider.stubs(:default_target).returns(file)
+      allow(provider).to receive(:default_target).and_return(file)
       provider.prefetch
 
       text = provider.to_file(provider.target_records(file))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ default_facts.each do |fact, value|
 end
 
 RSpec.configure do |c|
+  c.mock_with :rspec
   c.default_facts = default_facts
   c.before :each do
     # set to strictest setting for testing

--- a/spec/unit/provider/mount/parsed_spec.rb
+++ b/spec/unit/provider/mount/parsed_spec.rb
@@ -19,7 +19,7 @@ describe Puppet::Type.type(:mount).provider(:parsed), unless: Puppet.features.mi
     "/dev/vg00/lv01\t/spare   \t  \t   ext3    defaults\t1 2"
   end
 
-  # LAK:FIXME I can't mock Facter because this test happens at parse-time.
+  # LAK:FIXME I can't double Facter because this test happens at parse-time.
   it 'defaults to /etc/vfstab on Solaris' do
     if Facter.value(:osfamily) != 'Solaris'
       skip('This test only works on Solaris')
@@ -112,8 +112,8 @@ FSTAB
 
   describe 'mountinstances' do
     it 'gets name from mountoutput found on Solaris' do
-      Facter.stubs(:value).with(:osfamily).returns 'Solaris'
-      described_class.stubs(:mountcmd).returns(File.read(my_fixture('solaris.mount')))
+      allow(Facter).to receive(:value).with(:osfamily).and_return 'Solaris'
+      allow(described_class).to receive(:mountcmd).and_return(File.read(my_fixture('solaris.mount')))
       mounts = described_class.mountinstances
       expect(mounts.size).to eq(6)
       expect(mounts[0]).to eq(name: '/', mounted: :yes)
@@ -125,8 +125,8 @@ FSTAB
     end
 
     it 'gets name from mountoutput found on HP-UX' do
-      Facter.stubs(:value).with(:osfamily).returns 'HP-UX'
-      described_class.stubs(:mountcmd).returns(File.read(my_fixture('hpux.mount')))
+      allow(Facter).to receive(:value).with(:osfamily).and_return 'HP-UX'
+      allow(described_class).to receive(:mountcmd).and_return(File.read(my_fixture('hpux.mount')))
       mounts = described_class.mountinstances
       expect(mounts.size).to eq(17)
       expect(mounts[0]).to eq(name: '/', mounted: :yes)
@@ -149,8 +149,8 @@ FSTAB
     end
 
     it 'gets name from mountoutput found on Darwin' do
-      Facter.stubs(:value).with(:osfamily).returns 'Darwin'
-      described_class.stubs(:mountcmd).returns(File.read(my_fixture('darwin.mount')))
+      allow(Facter).to receive(:value).with(:osfamily).and_return 'Darwin'
+      allow(described_class).to receive(:mountcmd).and_return(File.read(my_fixture('darwin.mount')))
       mounts = described_class.mountinstances
       expect(mounts.size).to eq(6)
       expect(mounts[0]).to eq(name: '/', mounted: :yes)
@@ -162,8 +162,8 @@ FSTAB
     end
 
     it 'gets name from mountoutput found on Linux' do
-      Facter.stubs(:value).with(:osfamily).returns 'Gentoo'
-      described_class.stubs(:mountcmd).returns(File.read(my_fixture('linux.mount')))
+      allow(Facter).to receive(:value).with(:osfamily).and_return 'Gentoo'
+      allow(described_class).to receive(:mountcmd).and_return(File.read(my_fixture('linux.mount')))
       mounts = described_class.mountinstances
       expect(mounts[0]).to eq(name: '/', mounted: :yes)
       expect(mounts[1]).to eq(name: '/lib64/rc/init.d', mounted: :yes)
@@ -175,8 +175,8 @@ FSTAB
     end
 
     it 'gets name from mountoutput found on AIX' do
-      Facter.stubs(:value).with(:osfamily).returns 'AIX'
-      described_class.stubs(:mountcmd).returns(File.read(my_fixture('aix.mount')))
+      allow(Facter).to receive(:value).with(:osfamily).and_return 'AIX'
+      allow(described_class).to receive(:mountcmd).and_return(File.read(my_fixture('aix.mount')))
       mounts = described_class.mountinstances
       expect(mounts[0]).to eq(name: '/', mounted: :yes)
       expect(mounts[1]).to eq(name: '/usr', mounted: :yes)
@@ -190,16 +190,16 @@ FSTAB
     end
 
     it 'raises an error if a line is not understandable' do
-      described_class.stubs(:mountcmd).returns('bazinga!')
+      allow(described_class).to receive(:mountcmd).and_return('bazinga!')
       expect { described_class.mountinstances }.to raise_error Puppet::Error, 'Could not understand line bazinga! from mount output'
     end
   end
 
   it "supports AIX's paragraph based /etc/filesystems" do
     pending 'This test only works on AIX' unless Facter.value(:osfamily) == 'AIX'
-    Facter.stubs(:value).with(:osfamily).returns 'AIX'
-    described_class.stubs(:default_target).returns my_fixture('aix.filesystems')
-    described_class.stubs(:mountcmd).returns File.read(my_fixture('aix.mount'))
+    allow(Facter).to receive(:value).with(:osfamily).and_return 'AIX'
+    allow(described_class).to receive(:default_target).and_return my_fixture('aix.filesystems')
+    allow(described_class).to receive(:mountcmd).and_return File.read(my_fixture('aix.mount'))
     instances = described_class.instances
     expect(instances[0].name).to eq('/')
     expect(instances[0].device).to eq('/dev/hd4')
@@ -220,19 +220,19 @@ FSTAB
       end
 
       before :each do
-        Facter.stubs(:value).with(:osfamily).returns platform
+        allow(Facter).to receive(:value).with(:osfamily).and_return platform
         if Facter[:osfamily] == 'Solaris'
           platform == 'solaris' ||
-            skip("We need to stub the operatingsystem fact at load time, but can't")
+            skip("We need to double the operatingsystem fact at load time, but can't")
         else
           platform != 'solaris' ||
-            skip("We need to stub the operatingsystem fact at load time, but can't")
+            skip("We need to double the operatingsystem fact at load time, but can't")
         end
 
         # Stub the mount output to our fixture.
         begin
           mount = my_fixture(platform + '.mount')
-          described_class.stubs(:mountcmd).returns File.read(mount)
+          allow(described_class).to receive(:mountcmd).and_return File.read(mount)
         rescue
           skip "is #{platform}.mount missing at this point?"
         end
@@ -240,7 +240,7 @@ FSTAB
         # Note: we have to stub default_target before creating resources
         # because it is used by Puppet::Type::Mount.new to populate the
         # :target property.
-        described_class.stubs(:default_target).returns fstab
+        allow(described_class).to receive(:default_target).and_return fstab
       end
 
       # Following mountpoint are present in all fstabs/mountoutputs
@@ -274,17 +274,17 @@ FSTAB
       end
 
       before :each do
-        Facter.stubs(:value).with(:kernel).returns 'Linux'
-        Facter.stubs(:value).with(:operatingsystem).returns 'RedHat'
-        Facter.stubs(:value).with(:osfamily).returns 'RedHat'
+        allow(Facter).to receive(:value).with(:kernel).and_return 'Linux'
+        allow(Facter).to receive(:value).with(:operatingsystem).and_return 'RedHat'
+        allow(Facter).to receive(:value).with(:osfamily).and_return 'RedHat'
         begin
           mount = my_fixture('linux.mount')
-          described_class.stubs(:mountcmd).returns File.read(mount)
+          allow(described_class).to receive(:mountcmd).and_return File.read(mount)
         rescue
           skip 'is linux.mount missing at this point?'
         end
 
-        described_class.stubs(:default_target).returns my_fixture('linux.fstab')
+        allow(described_class).to receive(:default_target).and_return my_fixture('linux.fstab')
       end
 
       describe 'when handling whitespaces in mountpoints' do
@@ -332,21 +332,21 @@ FSTAB
 
       before :each do
         [:osfamily, :operatingsystem, :kernel].each do |fact|
-          Facter.stubs(:value).with(fact).returns platform
+          allow(Facter).to receive(:value).with(fact).and_return platform
         end
 
         if Facter[:osfamily] == 'Solaris'
           platform == 'solaris' ||
-            skip("We need to stub the operatingsystem fact at load time, but can't")
+            skip("We need to double the operatingsystem fact at load time, but can't")
         else
           platform != 'solaris' ||
-            skip("We need to stub the operatingsystem fact at load time, but can't")
+            skip("We need to double the operatingsystem fact at load time, but can't")
         end
 
         # Stub the mount output to our fixture.
         begin
           mount = my_fixture(platform + '.mount')
-          described_class.stubs(:mountcmd).returns File.read(mount)
+          allow(described_class).to receive(:mountcmd).and_return File.read(mount)
         rescue
           skip "is #{platform}.mount missing at this point?"
         end
@@ -354,7 +354,7 @@ FSTAB
         # Note: we have to stub default_target before creating resources
         # because it is used by Puppet::Type::Mount.new to populate the
         # :target property.
-        described_class.stubs(:default_target).returns fstab
+        allow(described_class).to receive(:default_target).and_return fstab
       end
 
       describe 'on other platforms than Solaris', if: Facter.value(:osfamily) != 'Solaris' do

--- a/spec/unit/provider/mount_spec.rb
+++ b/spec/unit/provider/mount_spec.rb
@@ -9,61 +9,61 @@ describe Puppet::Provider::Mount do
     mounter
   end
   let(:name) { '/' }
-  let(:resource) { stub 'resource' }
+  let(:resource) { instance_double(Puppet::Resource) }
 
   before :each do
-    resource.stubs(:[]).with(:name).returns(name)
-    mounter.stubs(:resource).returns(resource)
+    allow(resource).to receive(:[]).with(:name).and_return(name)
+    allow(mounter).to receive(:resource).and_return(resource)
   end
 
   describe described_class, ' when mounting' do
     before :each do
-      mounter.stubs(:get).with(:ensure).returns(:mounted)
+      allow(mounter).to receive(:get).with(:ensure).and_return(:mounted)
     end
 
     it "uses the 'mountcmd' method to mount" do
-      mounter.stubs(:options).returns(nil)
-      mounter.expects(:mountcmd)
+      allow(mounter).to receive(:options).and_return(nil)
+      expect(mounter).to receive(:mountcmd)
 
       mounter.mount
     end
 
     it "adds the options following '-o' on MacOS if they exist and are not set to :absent" do
-      Facter.expects(:value).with(:kernel).returns 'Darwin'
-      mounter.stubs(:options).returns('ro')
-      mounter.expects(:mountcmd).with '-o', 'ro', '/'
+      expect(Facter).to receive(:value).with(:kernel).and_return 'Darwin'
+      allow(mounter).to receive(:options).and_return('ro')
+      expect(mounter).to receive(:mountcmd).with '-o', 'ro', '/'
 
       mounter.mount
     end
 
     it 'does not explicitly pass mount options on systems other than MacOS' do
-      Facter.expects(:value).with(:kernel).returns 'HP-UX'
-      mounter.stubs(:options).returns('ro')
-      mounter.expects(:mountcmd).with '/'
+      expect(Facter).to receive(:value).with(:kernel).and_return 'HP-UX'
+      allow(mounter).to receive(:options).and_return('ro')
+      expect(mounter).to receive(:mountcmd).with '/'
 
       mounter.mount
     end
 
     it 'specifies the filesystem name to the mount command' do
-      mounter.stubs(:options).returns(nil)
-      mounter.expects(:mountcmd).with { |*ary| ary[-1] == name }
+      allow(mounter).to receive(:options).and_return(nil)
+      expect(mounter).to receive(:mountcmd) { |*ary| ary[-1] == name }
 
       mounter.mount
     end
 
     it 'updates the :ensure state to :mounted if it was :unmounted before' do
-      mounter.expects(:mountcmd)
-      mounter.stubs(:options).returns(nil)
-      mounter.expects(:get).with(:ensure).returns(:unmounted)
-      mounter.expects(:set).with(ensure: :mounted)
+      expect(mounter).to receive(:mountcmd)
+      allow(mounter).to receive(:options).and_return(nil)
+      expect(mounter).to receive(:get).with(:ensure).and_return(:unmounted)
+      expect(mounter).to receive(:set).with(ensure: :mounted)
       mounter.mount
     end
 
     it 'updates the :ensure state to :ghost if it was :absent before' do
-      mounter.expects(:mountcmd)
-      mounter.stubs(:options).returns(nil)
-      mounter.expects(:get).with(:ensure).returns(:absent)
-      mounter.expects(:set).with(ensure: :ghost)
+      expect(mounter).to receive(:mountcmd)
+      allow(mounter).to receive(:options).and_return(nil)
+      expect(mounter).to receive(:get).with(:ensure).and_return(:absent)
+      expect(mounter).to receive(:set).with(ensure: :ghost)
       mounter.mount
     end
   end
@@ -72,98 +72,98 @@ describe Puppet::Provider::Mount do
     context 'if the resource supports remounting' do
       context 'given explicit options on AIX' do
         it "combines the options with 'remount'" do
-          mounter.stubs(:info)
-          mounter.stubs(:options).returns('ro')
-          resource.stubs(:[]).with(:remounts).returns(:true)
-          Facter.expects(:value).with(:operatingsystem).returns 'AIX'
-          mounter.expects(:mountcmd).with('-o', 'ro,remount', name)
+          allow(mounter).to receive(:info)
+          allow(mounter).to receive(:options).and_return('ro')
+          allow(resource).to receive(:[]).with(:remounts).and_return(:true)
+          expect(Facter).to receive(:value).with(:operatingsystem).and_return 'AIX'
+          expect(mounter).to receive(:mountcmd).with('-o', 'ro,remount', name)
           mounter.remount
         end
       end
 
       it "uses '-o remount'" do
-        mounter.stubs(:info)
-        resource.stubs(:[]).with(:remounts).returns(:true)
-        mounter.expects(:mountcmd).with('-o', 'remount', name)
+        allow(mounter).to receive(:info)
+        allow(resource).to receive(:[]).with(:remounts).and_return(:true)
+        expect(mounter).to receive(:mountcmd).with('-o', 'remount', name)
         mounter.remount
       end
     end
 
     it "mounts with '-o update' on OpenBSD" do
-      mounter.stubs(:info)
-      mounter.stubs(:options)
-      resource.stubs(:[]).with(:remounts).returns(false)
-      Facter.expects(:value).with(:operatingsystem).returns 'OpenBSD'
-      mounter.expects(:mountcmd).with('-o', 'update', name)
+      allow(mounter).to receive(:info)
+      allow(mounter).to receive(:options)
+      allow(resource).to receive(:[]).with(:remounts).and_return(false)
+      expect(Facter).to receive(:value).with(:operatingsystem).and_return 'OpenBSD'
+      expect(mounter).to receive(:mountcmd).with('-o', 'update', name)
       mounter.remount
     end
 
     it 'unmounts and mount if the resource does not specify it supports remounting' do
-      mounter.stubs(:info)
-      mounter.stubs(:options)
-      resource.stubs(:[]).with(:remounts).returns(false)
-      Facter.expects(:value).with(:operatingsystem).returns 'AIX'
-      mounter.expects(:mount)
-      mounter.expects(:unmount)
+      allow(mounter).to receive(:info)
+      allow(mounter).to receive(:options)
+      allow(resource).to receive(:[]).with(:remounts).and_return(false)
+      expect(Facter).to receive(:value).with(:operatingsystem).and_return 'AIX'
+      expect(mounter).to receive(:mount)
+      expect(mounter).to receive(:unmount)
       mounter.remount
     end
 
     it 'logs that it is remounting' do
-      resource.stubs(:[]).with(:remounts).returns(:true)
-      mounter.stubs(:mountcmd)
-      mounter.expects(:info).with('Remounting')
+      allow(resource).to receive(:[]).with(:remounts).and_return(:true)
+      allow(mounter).to receive(:mountcmd)
+      expect(mounter).to receive(:info).with('Remounting')
       mounter.remount
     end
   end
 
   describe described_class, ' when unmounting' do
     before :each do
-      mounter.stubs(:get).with(:ensure).returns(:unmounted)
+      allow(mounter).to receive(:get).with(:ensure).and_return(:unmounted)
     end
 
     it 'calls the :umount command with the resource name' do
-      mounter.expects(:umount).with(name)
+      expect(mounter).to receive(:umount).with(name)
       mounter.unmount
     end
 
     it 'updates the :ensure state to :absent if it was :ghost before' do
-      mounter.expects(:umount).with(name).returns true
-      mounter.expects(:get).with(:ensure).returns(:ghost)
-      mounter.expects(:set).with(ensure: :absent)
+      expect(mounter).to receive(:umount).with(name).and_return true
+      expect(mounter).to receive(:get).with(:ensure).and_return(:ghost)
+      expect(mounter).to receive(:set).with(ensure: :absent)
       mounter.unmount
     end
 
     it 'updates the :ensure state to :unmounted if it was :mounted before' do
-      mounter.expects(:umount).with(name).returns true
-      mounter.expects(:get).with(:ensure).returns(:mounted)
-      mounter.expects(:set).with(ensure: :unmounted)
+      expect(mounter).to receive(:umount).with(name).and_return true
+      expect(mounter).to receive(:get).with(:ensure).and_return(:mounted)
+      expect(mounter).to receive(:set).with(ensure: :unmounted)
       mounter.unmount
     end
   end
 
   describe described_class, ' when determining if it is mounted' do
     it 'queries the property_hash' do
-      mounter.expects(:get).with(:ensure).returns(:mounted)
+      expect(mounter).to receive(:get).with(:ensure).and_return(:mounted)
       mounter.mounted?
     end
 
     it 'returns true if prefetched value is :mounted' do
-      mounter.stubs(:get).with(:ensure).returns(:mounted)
+      allow(mounter).to receive(:get).with(:ensure).and_return(:mounted)
       mounter.mounted? == true
     end
 
     it 'returns true if prefetched value is :ghost' do
-      mounter.stubs(:get).with(:ensure).returns(:ghost)
+      allow(mounter).to receive(:get).with(:ensure).and_return(:ghost)
       mounter.mounted? == true
     end
 
     it 'returns false if prefetched value is :absent' do
-      mounter.stubs(:get).with(:ensure).returns(:absent)
+      allow(mounter).to receive(:get).with(:ensure).and_return(:absent)
       mounter.mounted? == false
     end
 
     it 'returns false if prefetched value is :unmounted' do
-      mounter.stubs(:get).with(:ensure).returns(:unmounted)
+      allow(mounter).to receive(:get).with(:ensure).and_return(:unmounted)
       mounter.mounted? == false
     end
   end


### PR DESCRIPTION
To avoid having to update this everytime we release a new agent platform, it should be enough to specify the supported OS, without
specific versions. It is assumed that for each OS in metadata.json, the versions supported are the same as what the agent itself supports.