### PR TITLE
(maint) Create a larger filesystem

### DIFF
--- a/spec/acceptance/lib/mount_utils.rb
+++ b/spec/acceptance/lib/mount_utils.rb
@@ -65,7 +65,7 @@ module MountUtils
       on(host, "mklv -y #{mount_name} #{volume_group} 1M")
       on(host, "mkfs -V #{fs_type} -l #{mount_name} /dev/#{mount_name}")
     when %r{el-|centos|fedora|sles|debian|ubuntu|cumulus}
-      on(host, "dd if=/dev/zero of='/tmp/#{mount_name}' count=10240", acceptable_exit_codes: [0, 1])
+      on(host, "dd if=/dev/zero of='/tmp/#{mount_name}' count=16384", acceptable_exit_codes: [0, 1])
       on(host, "yes | mkfs -t #{fs_type} -q '/tmp/#{mount_name}'", acceptable_exit_codes: (0..254))
     else
       # TODO: Add Solaris and OSX support, as per PUP-5201 and PUP-4823


### PR DESCRIPTION
The test failed on Ubuntu 20.04 and 22.04 when executing this sequence:

    $ dd if=/dev/zero of='/tmp/pl139938' count=10240
    10240+0 records in
    10240+0 records out
    5242880 bytes (5.2 MB, 5.0 MiB) copied, 0.0422315 s, 124 MB/s
    $ yes | mkfs -t ext3 -q '/tmp/pl139938'

      Filesystem too small for a journal

The mkfs command fell back to creating an ext2 filesystem, which caused the
mount resource to fail:

    $ puppet resource mount /pl256676 ensure=mounted fstype=ext3 options=loop device=/tmp/pl256676
    Notice: /Mount[/pl256676]/ensure: defined 'ensure' as 'mounted'
    Error: /Mount[/pl256676]: Could not evaluate: Execution of '/usr/bin/mount /pl256676' returned 32: mount: /pl256676: wrong fs type, bad option, bad superblock on /dev/loop9, missing codepage or helper program, or other error.

This updates the block count to 16384 (of size 512), so the resulting file is 8MiB.