### PR TITLE
(MODULES-11367) Updates Ubuntu GitHub Actions runners

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -10,7 +10,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-latest', 'windows-2019' ]
+        os: [ 'ubuntu-20.04', 'macos-latest', 'windows-2019' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -18,7 +18,7 @@ jobs:
           - puppet_version: 7
             ruby: 2.7
 
-          - os: 'ubuntu-18.04'
+          - os: 'ubuntu-20.04'
             os_type: 'Linux'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest.gem'

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -15,7 +15,7 @@ jobs:
       ruby_version: 2.6
       extra_checks: check:symlinks check:git_ignore check:dot_underscore check:test_file
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
     steps:
       - name: Checkout current PR code
         uses: actions/checkout@v2

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-latest', 'windows-2019' ]
+        os: [ 'ubuntu-20.04', 'macos-latest', 'windows-2019' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -20,7 +20,7 @@ jobs:
           - puppet_version: 7
             ruby: 2.7
 
-          - os: 'ubuntu-18.04'
+          - os: 'ubuntu-20.04'
             os_type: 'Linux'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest.gem'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-latest', 'windows-2019' ]
+        os: [ 'ubuntu-20.04', 'macos-latest', 'windows-2019' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -20,7 +20,7 @@ jobs:
           - puppet_version: 7
             ruby: 2.7
 
-          - os: 'ubuntu-18.04'
+          - os: 'ubuntu-20.04'
             os_type: 'Linux'
           - os: 'macos-latest'
             os_type: 'macOS'

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
       "operatingsystem": "Fedora"
     },
     {
-      "operatingsystem": "Darwin"
+      "operatingsystem": "macOS"
     },
     {
       "operatingsystem": "SLES"


### PR DESCRIPTION
GitHub is deprecating Ubuntu 18.04 runners on April 1, 2023. This commit switches all Ubuntu 18.04 runners used in GitHub Actions to Ubuntu 20.04.