### PR TITLE
(MODULES-11371) Updates PDK template

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,38 @@
+# devcontainer
+
+
+For format details, see https://aka.ms/devcontainer.json. 
+
+For config options, see the README at:
+https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
+ 
+``` json
+{
+	"name": "Puppet Development Kit (Community)",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"puppet.puppet-vscode",
+		"rebornix.Ruby"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pdk --version",
+}
+```
+
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,17 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
 {
 	"name": "Puppet Development Kit (Community)",
 	"dockerFile": "Dockerfile",
 
-	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
 	},
 
-	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"puppet.puppet-vscode",
 		"rebornix.Ruby"
 	]
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pdk --version",
 }

--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+    
     - name: "Honeycomb: Start recording"
       uses: puppetlabs/kvrhdn-gha-buildevents@pdk-templates-v1
       with:
@@ -25,7 +26,6 @@ jobs:
       run: |
         echo STEP_ID="auto-release" >> $GITHUB_ENV
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
-
     - name: "Checkout Source"
       if: ${{ github.repository_owner == 'puppetlabs' }}
       uses: actions/checkout@v2
@@ -46,8 +46,14 @@ jobs:
       run: |
         echo "::set-output name=ver::$(jq --raw-output .version metadata.json)"
 
-    - name: "Commit changes"
+    - name: "Check if a release is necessary"
       if: ${{ github.repository_owner == 'puppetlabs' }}
+      id: check
+      run: |
+        git diff --quiet CHANGELOG.md && echo "::set-output name=release::false" || echo "::set-output name=release::true"
+
+    - name: "Commit changes"
+      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
       run: |
         git config --local user.email "${{ github.repository_owner }}@users.noreply.github.com"
         git config --local user.name "GitHub Action"
@@ -57,7 +63,7 @@ jobs:
     - name: Create Pull Request
       id: cpr
       uses: puppetlabs/peter-evans-create-pull-request@v3
-      if: ${{ github.repository_owner == 'puppetlabs' }}
+      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "Release prep v${{ steps.gv.outputs.ver }}"
@@ -73,11 +79,11 @@ jobs:
         labels: "maintenance"
 
     - name: PR outputs
-      if: ${{ github.repository_owner == 'puppetlabs' }}
+      if: ${{ github.repository_owner == 'puppetlabs' && steps.check.outputs.release == 'true' }}
       run: |
         echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
         echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
-
+ 
     - name: "Honeycomb: Record finish step"
       if: ${{ always() }}
       run: |

--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -33,10 +33,12 @@ jobs:
         fetch-depth: 0
         persist-credentials: false
 
+    # We use the dev tools image here because the PDK image does not have the
+    # build tools necessary to compile native extensions.
     - name: "PDK Release prep"
-      uses: docker://puppet/iac_release:ci
+      uses: docker://puppet/puppet-dev-tools:4.x
       with:
-        args: 'release prep --force'
+        args: 'pdk release prep --force --debug'
       env:
         CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -28,7 +28,7 @@ jobs:
         echo STEP_START=$(date +%s) >> $GITHUB_ENV
     - name: "Checkout Source"
       if: ${{ github.repository_owner == 'puppetlabs' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
         persist-credentials: false

--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install ruby version ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           clean: true
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
           clean: true

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: 'ubuntu-20.04'
     steps:
       - name: Checkout current PR code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current PR code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install ruby version ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -32,7 +32,7 @@ jobs:
       PUPPET_GEM_VERSION: ~> ${{ matrix.puppet_version }}.0
     steps:
       - name: Checkout current PR code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install ruby version ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 - rubocop-rspec
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.4'
+  TargetRubyVersion: '2.5'
   Include:
   - "**/*.rb"
   Exclude:

--- a/.sync.yml
+++ b/.sync.yml
@@ -34,6 +34,9 @@ Gemfile:
         from_env: BEAKER_PUPPET_VERSION
         version: '~> 1.22'
       - gem: github_changelog_generator
+        version: '= 1.16.4'
+      - gem: concurrent-ruby
+        version: '= 1.1.10'
       # We can unpin async when we move to Ruby 3
       - gem: async
         version: '~> 1'

--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,8 @@ group :development do
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1.22')
-  gem "github_changelog_generator",                                             require: false
+  gem "github_changelog_generator", '= 1.16.4',                                 require: false
+  gem "concurrent-ruby", '= 1.1.10',                                            require: false
   gem "async", '~> 1',                                                          require: false
   gem "beaker-module_install_helper",                                           require: false
   gem "beaker-puppet_install_helper",                                           require: false

--- a/Gemfile
+++ b/Gemfile
@@ -13,32 +13,42 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
-ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = ruby_version_segments[0..1].join('.')
-
 group :development do
-  gem "json", '= 2.0.4',                                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0',                 require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',                     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',                   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',                       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "json", '= 2.1.0',                                                        require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                                                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                                                        require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                                                        require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                                                        require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 3.1',                                require: false
+  gem "facterdb", '~> 1.18',                                                    require: false
+  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0',                              require: false
+  gem "puppetlabs_spec_helper", '>= 3.0.0', '< 5.0.0',                          require: false
+  gem "rspec-puppet-facts", '~> 2.0',                                           require: false
+  gem "codecov", '~> 0.2',                                                      require: false
+  gem "dependency_checker", '~> 0.2',                                           require: false
+  gem "parallel_tests", '~> 3.4',                                               require: false
+  gem "pry", '~> 0.10',                                                         require: false
+  gem "simplecov-console", '~> 0.5',                                            require: false
+  gem "puppet-debugger", '~> 1.0',                                              require: false
+  gem "rubocop", '= 1.6.1',                                                     require: false
+  gem "rubocop-performance", '= 1.9.1',                                         require: false
+  gem "rubocop-rspec", '= 2.0.1',                                               require: false
+  gem "rb-readline", '= 0.5.5',                                                 require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.30')
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.9')
-  gem "beaker-pe",                                                               require: false
+  gem "beaker-pe",                                                              require: false
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1.22')
-  gem "github_changelog_generator",                                              require: false
-  gem "async", '~> 1',                                                           require: false
-  gem "beaker-module_install_helper",                                            require: false
-  gem "beaker-puppet_install_helper",                                            require: false
-  gem "nokogiri",                                                                require: false
+  gem "github_changelog_generator",                                             require: false
+  gem "async", '~> 1',                                                          require: false
+  gem "beaker-module_install_helper",                                           require: false
+  gem "beaker-puppet_install_helper",                                           require: false
+  gem "nokogiri",                                                               require: false
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby]
+  gem "serverspec", '~> 2.41',    require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ end
 group :system_tests do
   gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby]
   gem "serverspec", '~> 2.41',    require: false
+  gem "voxpupuli-acceptance"
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,7 @@ end
 
 PuppetLint.configuration.send('disable_relative')
 
+
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
 require 'github_changelog_generator/task' if Bundler.rubygems.find_name('github_changelog_generator').any?
 require 'puppet-strings/tasks' if Bundler.rubygems.find_name('puppet-strings').any?
+require 'voxpupuli/acceptance/rake'
 
 def changelog_user
   return unless Rake.application.top_level_tasks.include? "changelog"

--- a/metadata.json
+++ b/metadata.json
@@ -51,10 +51,10 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 9.0.0"
     }
   ],
-  "pdk-version": "2.3.0",
-  "template-url": "https://github.com/puppetlabs/pdk-templates#2.2.0",
-  "template-ref": "tags/2.2.0-0-g2381db6"
+  "pdk-version": "2.6.1",
+  "template-url": "https://github.com/puppetlabs/pdk-templates#2.7.1",
+  "template-ref": "tags/2.7.1-0-g9a16c87"
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,7 @@
 require 'beaker-rspec'
 require 'beaker/module_install_helper'
 require 'beaker/puppet_install_helper'
+require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 $LOAD_PATH << File.join(__dir__, 'acceptance/lib')
 


### PR DESCRIPTION
This PR:
- Updates the PDK tempalte to 2.7.1.
- Sets metadata.json to allow Puppet versions < 9.0.0 in preparation for the release of Puppet 8.
- Updates actions/checkout from v2 to v3.

