### PR TITLE
Fix wrong descrpiton in the provider

### DIFF
--- a/lib/puppet/provider/mount/parsed.rb
+++ b/lib/puppet/provider/mount/parsed.rb
@@ -16,9 +16,7 @@ Puppet::Type.type(:mount).provide(
 ) do
   include Puppet::Provider::Mount
 
-  @doc = "Installs and manages host entries.  For most systems, these
-      entries will just be in `/etc/hosts`, but some systems (notably OS X)
-      will have different solutions."
+  @doc = 'Manages filesystem mounts'
 
   commands mountcmd: 'mount', umount: 'umount'
 


### PR DESCRIPTION
The provider manages file system mounts and is not at all related to hosts entries.