### PR TITLE
(PA-5395) Issues housekeeping

### DIFF
--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -1,0 +1,19 @@
+---
+name: Export issue to Jira
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  export:
+    uses: "puppetlabs/phoenix-github-actions/.github/workflows/jira.yml@main"
+    with:
+      jira-project: PA
+      jira-base-url: ${{ vars.jira_base_url }}
+      jira-user-email: ${{ vars.jira_user_email }}
+    secrets:
+      jira-api-token: ${{ secrets.JIRA_ISSUES_ACTION }}

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-mount_core",
   "project_page": "https://github.com/puppetlabs/puppetlabs-mount_core",
-  "issues_url": "https://tickets.puppetlabs.com/projects/MODULES",
+  "issues_url": "https://github.com/puppetlabs/puppetlabs-mount_core/issues",
   "dependencies": [
 
   ],


### PR DESCRIPTION
This PR:

- Updates the issues URL in metadata.json from Puppet's old Jira instance to GitHub Issues.
- Adds a workflow to export GitHub issues to Puppet's internal-only Jira instance.

